### PR TITLE
Update name of release to have cf-prefix

### DIFF
--- a/templates/riak-cs-service.yml
+++ b/templates/riak-cs-service.yml
@@ -6,7 +6,7 @@ networks: (( merge ))
 jobs: (( merge ))
 
 releases:
-- name: riak-cs
+- name: cf-riak-cs
   version: latest
 
 compilation:


### PR DESCRIPTION
In order to be consistent with other CF releases, e.g.:
https://github.com/cloudfoundry/cf-mysql-release/blob/master/templates/cf-mysql-template.yml
