### PR TITLE
Revert "Fixed a broken link"

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ $ cf delete-service-broker p-riakcs
 
 See [Clients for Riak CS](docs/clients.md) for a list of clients that have been validated to work with the service.
 
-[The included test application](http://github.com/cloudfoundry-incubator/cf-riak-cs-acceptance-tests/tree/master/assets/app_sinatra_service), written in Ruby and using the Fog library, is an example of how to use the service with an application.
+[The included test application](src/acceptance-tests/assets/app_sinatra_service), written in Ruby and using the Fog library, is an example of how to use the service with an application.
 
 ## Limitations
 


### PR DESCRIPTION
Reverts cloudfoundry/cf-riak-cs-release#25

I'm sorry, I had to revert this. I merged it against master, which was incorrect.

This pull request has been reviewed, and it sounds good. BUT, it's filed against the wrong branch - it should be filed against develop, not master. We've only just published a [CONTRIBUTING](https://github.com/cloudfoundry/cf-riak-cs-release/blob/develop/CONTRIBUTING.md) file, please check it out.

If you could please retract this PR, and re-submit it against develop, I'll be very grateful.

--
  Marco Nicosia
  Product Manager
  Pivotal Software, Inc.
