### PR TITLE
Allow seeded_buckets to be specified in templates

### DIFF
--- a/templates/riak-cs-jobs.yml
+++ b/templates/riak-cs-jobs.yml
@@ -26,6 +26,7 @@ jobs:
       ips:  (( jobs.[0].networks.[0].static_ips ))
       admin_key: (( meta.riak_cs.admin_key ))
       admin_secret: (( meta.riak_cs.admin_secret ))
+      seeded_buckets: (( meta.riak_cs.seeded_buckets || nil ))
       port: ~
       register_route: ~
     nats: (( meta.nats ))


### PR DESCRIPTION
Same as https://github.com/cloudfoundry/cf-riak-cs-release/pull/26 but now at with correct target branch.