### PR TITLE
Added a more robust monit check that looks for response from riak-cs ping endpoint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing to cf-riak-cs-release
+
+## Contributor License Agreement
+
+Follow these steps to make a contribution to any of CF open source repositories:
+
+1. Ensure that you have completed our CLA Agreement for
+   [individuals](http://www.cloudfoundry.org/individualcontribution.pdf) or
+   [corporations](http://www.cloudfoundry.org/corpcontribution.pdf).
+
+1. Set your name and email (these should match the information on your submitted CLA)
+
+        git config --global user.name "Firstname Lastname"
+        git config --global user.email "your_email@example.com"
+
+1. Submit a Pull Request
+    1. Fork the repository on github
+
+    1. Update submodules (`./update`)
+
+    1. Create a feature branch (`git checkout -b awesome_sauce`)
+        * Run the tests to ensure that your local environment is working `./scripts/test_submodules`
+
+    1. Make changes on the branch:
+        * Adding a feature
+          1. Add tests for the new feature
+          1. Make the tests pass
+        * Fixing a bug
+          1. Add a test/tests which exercises the bug
+          1. Fix the bug, making the tests pass
+        * Refactoring existing functionality
+          1. Change the implementation
+          1. Ensure that tests still pass
+            * If you find yourself changing tests after a refactor, consider refactoring the tests first
+
+    1. Run the [acceptance tests](docs/acceptance-tests.md) (update them if required).
+
+    1. Commit your changes (`git commit`)
+        * Small changes per commit with clear commit messages are preferred.
+
+    1. Push to your fork (`git push origin awesome_sauce`)
+
+    1. Submit a pull request in github, selecting `develop` as the target branch.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Pushing to any branch other than [**develop**](https://github.com/cloudfoundry/c
 
 ## Development
 
+See our [contributing docs](CONTRIBUTING.md) for instructions on how to make a pull request.
+
 This BOSH release doubles as a `$GOPATH`. It will automatically be set up for
 you if you have [direnv](http://direnv.net) installed.
 

--- a/jobs/riak-cs/monit
+++ b/jobs/riak-cs/monit
@@ -8,6 +8,11 @@ check process riak-cs
   with pidfile /var/vcap/sys/run/riak-cs/riak-cs.pid
   start program "/var/vcap/jobs/riak-cs/bin/riak-cs_ctl start"
   stop program "/var/vcap/jobs/riak-cs/bin/riak-cs_ctl stop"
+  if failed 
+    host localhost port 8080 and 
+          send "GET / HTTP/1.1\r\nHost: localhost\riak-cs\ping\r\n\r\n"
+          expect "HTTP/[0-9\.]{3} 200.*"
+    then restart
   group vcap
 
 <% if properties.riak_cs.register_route %>

--- a/jobs/riak-cs/monit
+++ b/jobs/riak-cs/monit
@@ -8,10 +8,9 @@ check process riak-cs
   with pidfile /var/vcap/sys/run/riak-cs/riak-cs.pid
   start program "/var/vcap/jobs/riak-cs/bin/riak-cs_ctl start"
   stop program "/var/vcap/jobs/riak-cs/bin/riak-cs_ctl stop"
-  if failed 
-    host localhost port 8080 and 
-          send "GET / HTTP/1.1\r\nHost: localhost\riak-cs\ping\r\n\r\n"
-          expect "HTTP/[0-9\.]{3} 200.*"
+  if failed
+    host localhost port 8080 protocol http 
+      and request "/riak-cs/ping"
     then restart
   group vcap
 


### PR DESCRIPTION
Currently, it is possible under several circumstances (e.g. disk capacity is maxed out) for the Riak-CS pid file to exist even when the process has stopped or stopped responding.  As such, monit will not attempt a restart if the pid file exists.  We have added a secondary monit failure check to verify that the riak-cs heartbeat endpoint at "/riak-cs/ping" is also responding.  If not, monit with detect the failure condition and restart the riak-cs process.