### PR TITLE
Added a more robust monit check that looks for response from riak-cs ping endpoint

### DIFF
--- a/jobs/riak-cs/monit
+++ b/jobs/riak-cs/monit
@@ -8,6 +8,11 @@ check process riak-cs
   with pidfile /var/vcap/sys/run/riak-cs/riak-cs.pid
   start program "/var/vcap/jobs/riak-cs/bin/riak-cs_ctl start"
   stop program "/var/vcap/jobs/riak-cs/bin/riak-cs_ctl stop"
+  if failed 
+    host localhost port 8080 and 
+          send "GET / HTTP/1.1\r\nHost: localhost\riak-cs\ping\r\n\r\n"
+          expect "HTTP/[0-9\.]{3} 200.*"
+    then restart
   group vcap
 
 <% if properties.riak_cs.register_route %>

--- a/jobs/riak-cs/monit
+++ b/jobs/riak-cs/monit
@@ -8,10 +8,9 @@ check process riak-cs
   with pidfile /var/vcap/sys/run/riak-cs/riak-cs.pid
   start program "/var/vcap/jobs/riak-cs/bin/riak-cs_ctl start"
   stop program "/var/vcap/jobs/riak-cs/bin/riak-cs_ctl stop"
-  if failed 
-    host localhost port 8080 and 
-          send "GET / HTTP/1.1\r\nHost: localhost\riak-cs\ping\r\n\r\n"
-          expect "HTTP/[0-9\.]{3} 200.*"
+  if failed
+    host localhost port 8080 protocol http 
+      and request "/riak-cs/ping"
     then restart
   group vcap
 


### PR DESCRIPTION
Currently, it is possible under several circumstances (e.g. disk capacity is maxed out) for the Riak-CS pid file to exist even when the process has stopped or stopped responding. As such, monit will not attempt a restart if the pid file exists. We have added a secondary monit failure check to verify that the riak-cs heartbeat endpoint at "/riak-cs/ping" is also responding. If not, monit with detect the failure condition and restart the riak-cs process.
