### PR TITLE
Templates for OpenStack deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,21 @@ To tweak the deployment settings, you can modify the resulting file `cf-riak-cs-
   $ bosh deployment cf-riak-cs-aws.yml && bosh deploy
   ```
 
+#### OpenStack<a name="openstack"></a>
+
+1. Create a stub file called cf-riak-cs-openstack-stub.yml by copying and modifying the [sample_openstack_stub.yml](https://github.com/cloudfoundry/cf-riak-cs-release/blob/master/templates/sample_stubs/sample_openstack_stub.yml) in templates/sample_stubs.
+
+1. Generate the manifest:
+  ```
+  $ ./generate_deployment_manifest openstack cf-riak-cs-openstack-stub.yml > cf-riak-cs-openstack.yml
+  ```
+To tweak the deployment settings, you can modify the resulting file `cf-riak-cs-openstack.yml`. Eg you may have different names for resource flavours in your OpenStack deployment or you may need to explicitly specify a static IP for the service broker.
+
+1. To deploy:
+  ```
+  $ bosh deployment cf-riak-cs-openstack.yml && bosh deploy
+  ```
+
 #### Deployment Manifest Properties<a name="stub-properties"></a>
 
 Manifest properties are described in the `spec` file for each job; see [jobs](jobs).

--- a/generate_deployment_manifest
+++ b/generate_deployment_manifest
@@ -6,8 +6,9 @@ infrastructure=$1
 
 if [ "$infrastructure" != "warden" ] && \
     [ "$infrastructure" != "vsphere" ] && \
-    [ "$infrastructure" != "aws" ]; then
-  echo "usage: ./generate_deployment_manifest <warden|vsphere|aws> [stubs...]"
+    [ "$infrastructure" != "aws" ] && \
+    [ "$infrastructure" != "openstack" ]; then
+  echo "usage: ./generate_deployment_manifest <warden|vsphere|aws|openstack> [stubs...]"
   exit 1
 fi
 

--- a/packages/route-registrar/spec
+++ b/packages/route-registrar/spec
@@ -10,6 +10,7 @@ files:
   - github.com/cloudfoundry-incubator/route-registrar/healthchecker/fakes/*.go # gosub
   - github.com/cloudfoundry-incubator/route-registrar/registrar/*.go # gosub
   - github.com/cloudfoundry-incubator/route-registrar/test_helpers/*.go # gosub
+  - github.com/apcera/nats/*.go # gosub
   - github.com/cloudfoundry-incubator/route-registrar/Godeps/_workspace/src/github.com/cloudfoundry-incubator/cf-lager/*.go # gosub
   - github.com/cloudfoundry-incubator/route-registrar/Godeps/_workspace/src/github.com/cloudfoundry/gibson/*.go # gosub
   - github.com/cloudfoundry-incubator/route-registrar/Godeps/_workspace/src/github.com/cloudfoundry/yagnats/*.go # gosub

--- a/packages/route-registrar/spec
+++ b/packages/route-registrar/spec
@@ -10,7 +10,6 @@ files:
   - github.com/cloudfoundry-incubator/route-registrar/healthchecker/fakes/*.go # gosub
   - github.com/cloudfoundry-incubator/route-registrar/registrar/*.go # gosub
   - github.com/cloudfoundry-incubator/route-registrar/test_helpers/*.go # gosub
-  - github.com/apcera/nats/*.go # gosub
   - github.com/cloudfoundry-incubator/route-registrar/Godeps/_workspace/src/github.com/cloudfoundry-incubator/cf-lager/*.go # gosub
   - github.com/cloudfoundry-incubator/route-registrar/Godeps/_workspace/src/github.com/cloudfoundry/gibson/*.go # gosub
   - github.com/cloudfoundry-incubator/route-registrar/Godeps/_workspace/src/github.com/cloudfoundry/yagnats/*.go # gosub

--- a/templates/openstack-networks.yml
+++ b/templates/openstack-networks.yml
@@ -1,0 +1,17 @@
+networks:
+- name: riak-cs1
+  type: manual
+  subnets:
+  - name: default_subnet
+    range: ((merge))
+    reserved: ((merge))
+    static: ((merge))
+    gateway: ((merge))
+    dns: ((merge))
+    cloud_properties:
+      security_groups: ((merge))
+      net_id: (( merge ))
+- name: compilation
+  type: dynamic
+  cloud_properties:
+    net_id: (( merge ))

--- a/templates/openstack-properties.yml
+++ b/templates/openstack-properties.yml
@@ -1,0 +1,10 @@
+jobs:
+  - name: riak-cs
+    properties:
+      riak:
+        firewall_enabled: true
+#      riak_cs:
+#        cloud: "openstack"
+#        cs_os_root_host: (( merge ))
+#        cs_admin_token: (( merge ))
+#        cs_auth_url: (( merge ))

--- a/templates/openstack-properties.yml
+++ b/templates/openstack-properties.yml
@@ -3,8 +3,3 @@ jobs:
     properties:
       riak:
         firewall_enabled: true
-#      riak_cs:
-#        cloud: "openstack"
-#        cs_os_root_host: (( merge ))
-#        cs_admin_token: (( merge ))
-#        cs_auth_url: (( merge ))

--- a/templates/openstack-resource-pools.yml
+++ b/templates/openstack-resource-pools.yml
@@ -1,0 +1,24 @@
+---
+
+compilation:
+  cloud_properties:
+    instance_type: (( merge || "m1.medium" ))
+  network: riak-cs1
+  reuse_compilation_vms: true
+  workers: 2
+
+resource_pools:
+- name: riak-pool
+  network: riak-cs1
+  stemcell:
+    name: bosh-openstack-kvm-ubuntu-trusty-go_agent
+    version: latest
+  cloud_properties:
+    instance_type: m1.large
+- name: broker-pool
+  network: riak-cs1
+  stemcell:
+    name: bosh-openstack-kvm-ubuntu-trusty-go_agent
+    version: latest
+  cloud_properties:
+    instance_type: m1.large

--- a/templates/sample_stubs/sample_openstack_stub.yml
+++ b/templates/sample_stubs/sample_openstack_stub.yml
@@ -1,0 +1,50 @@
+director_uuid: YOUR_DIRECTOR_GUID
+# This example uses a 10.10.126.0/20 subnet.  Adjust to match what you actually have.
+networks:
+  - name: riak-cs1
+    type: manual
+    subnets:
+    - name: default_subnet
+      range: 10.10.128.0/20
+      reserved:
+        - 10.10.128.2 - 10.10.131.255
+        - 10.10.133.1 - 10.10.143.254
+      static:
+        - 10.10.132.1 - 10.10.132.100
+      gateway: 10.10.128.1
+      dns:
+        - 10.10.0.2
+      cloud_properties:
+        security_groups: YOUR_OPENSTACK_SECURITY_GROUPS
+        net_id: YOUR_OPENSTACK_SERVICES_NETWORK_ID
+  - name: compilation
+    cloud_properties:
+      net_id: YOUR_OPENSTACK_COMPILATION_NETWORK_ID
+
+properties:
+  domain: YOUR_CF_SYSTEM_DOMAIN
+  app_domains:
+  - YOUR_CF_APP_DOMAIN
+
+  nats:
+    machines:
+    - IP_OF_NATS_SERVER
+    user: nats
+    password: YOUR_CF_NATS_PASSWORD
+    port: 4222
+  cf:
+    api_url: https://api.YOUR_CF_SYSTEM_DOMAIN
+    admin_username: YOUR_CF_ADMIN_USERNAME
+    admin_password: YOUR_CF_ADMIN_PASSWORD
+  broker:
+    name: p-riakcs
+    # credentials used by cloud controller to authenticate with the broker
+    username: BROKER_USERNAME
+    password: BROKER_PASSWORD
+  riak_cs:
+    # credentials for Riak CS admin user
+    admin_key: ADMIN-KEY
+    admin_secret: ADMIN-SECRET
+
+meta:
+  environment: ENVIRONMENT


### PR DESCRIPTION
Here are some templates to start with when it comes to deploying the release to OpenStack.

They are quite similar to the AWS ones, except for:
* `net_id` field instead of `subnet` for networks configuration
* `bosh-openstack-kvm-ubuntu-trusty-go_agent` stemcell
* a separate network for compilation to avoid possible IP allocation problems

Using this templates I've managed to deploy the release on a Mirantis Openstack 5.1.1 deployment.