### PR TITLE
Fixed iptables rule duplication, and cluster expansion issues

### DIFF
--- a/jobs/riak-cs/templates/restrict_riak_requests_to_cluster_ip_range.sh.erb
+++ b/jobs/riak-cs/templates/restrict_riak_requests_to_cluster_ip_range.sh.erb
@@ -5,7 +5,7 @@ function add_rule_if_not_there() {
   criterion2=$2
   iptables_command=$3
 
-  iptables -L | grep $criterion1 | grep $criterion2 > /dev/null
+  iptables -n -L | grep $criterion1 | grep $criterion2 > /dev/null
   if [ "$?" != "0" ]; then
     `$iptables_command`
   fi
@@ -14,10 +14,15 @@ function add_rule_if_not_there() {
 # external Riak access
 <% (Array(p('riak_cs.ips')) + [p('stanchion.ip')]).each do |ip| %>
   add_rule_if_not_there <%= ip %> 8087 "iptables -A INPUT -p tcp --dport 8087 -s <%= ip %> -j ACCEPT"
-  add_rule_if_not_there <%= ip %> 8098 "iptables -A INPUT -p tcp --dport 8087 -s <%= ip %> -j ACCEPT"
+  add_rule_if_not_there <%= ip %> 8098 "iptables -A INPUT -p tcp --dport 8098 -s <%= ip %> -j ACCEPT"
 <% end %>
+# drop the drops, to handle cluster expansion properly
+iptables -D INPUT -p tcp --dport 8087 -j DROP
+iptables -D INPUT -p tcp --dport 8098 -j DROP
+
+# re-add the drops at the end
 add_rule_if_not_there DROP 8087 "iptables -A INPUT -p tcp --dport 8087 -j DROP"
-add_rule_if_not_there DROP 8098 "iptables -A INPUT -p tcp --dport 8087 -j DROP"
+add_rule_if_not_there DROP 8098 "iptables -A INPUT -p tcp --dport 8098 -j DROP"
 
 # intra-cluster Riak access
 <% (Array(p('riak.ips')) + ['127.0.0.1']).each do |ip| %>
@@ -25,6 +30,12 @@ add_rule_if_not_there DROP 8098 "iptables -A INPUT -p tcp --dport 8087 -j DROP"
   add_rule_if_not_there <%= ip %> 8099 "iptables -A INPUT -p tcp --dport 8099 -s <%= ip %> -j ACCEPT"
   add_rule_if_not_there <%= ip %> 6001:6100 "iptables -A INPUT -p tcp --dport 6001:6100 -s <%= ip %> -j ACCEPT"
 <% end %>
+# drop the drops, to handle cluster expansion properly
+iptables -D INPUT -p tcp --dport 4369 -j DROP
+iptables -D INPUT -p tcp --dport 8099 -j DROP
+iptables -D INPUT -p tcp --dport 6001:6100 -j DROP
+
+# re-add the drops at the end
 add_rule_if_not_there DROP 4369 "iptables -A INPUT -p tcp --dport 4369 -j DROP"
 add_rule_if_not_there DROP 8099 "iptables -A INPUT -p tcp --dport 8099 -j DROP"
 add_rule_if_not_there DROP 6001:6100 "iptables -A INPUT -p tcp --dport 6001:6100 -j DROP"


### PR DESCRIPTION
Every time `monit restart` was used on the `riak-cs` job,
the `restrict_riak_requests_to_clister_ip_range.sh` script
would duplicate a few rules, partly due to some of the ports
having service names in /etc/services (on some platforms), and
partly due to a bad rule addition. `monit restart` should no longer
cause duplicate rules to show up in iptables.

Additionally, the rules should now be updated in a fashion that
allows additional nodes to be added to the cluster/firewall rules,
and talk to the original nodes. Previously, new rules were appended
after any initial DROPs, which could lead to problems.
